### PR TITLE
Allow user choice of g_mass_storage vs g_multi

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,11 +351,33 @@ Open an SSH shell to your pi, and run `sudo dmesg -w` and watch if this log gets
 [167504.648298] dwc2 20980000.usb: new device is full-speed
 [167504.686546] dwc2 20980000.usb: new address 1
 ```
-If this is the case, open the file `/usr/local/share/usbshare.py` and change the CMD lines to this, and restart the pi:
+If this is the case, reinstall the service using the g_mass_storage driver, or manually update the script above, replacing 'g_multi' with 'g_mass_storage'.
 ```
-CMD_MOUNT = "sudo /sbin/modprobe g_mass_storage file=/piusb.bin stall=0 ro=1 removable=y"
-CMD_UNMOUNT = "sudo /sbin/modprobe g_mass_storage -r"
+sudo ./install.sh g_mass_storage
+```
+If you are watching `sudo dmesg -w` in another ssh session, you will see this change drivers, and hopefully will work for you. It shoudl stop repeating the device connected messages, and only have 1 record.
 ```
 
-//TODO, provide a command in the install script to automatically change that, 
-
+[171127.975803] dwc2 20980000.usb: new address 1
+[171134.612520] dwc2 20980000.usb: new device is full-speed
+[171134.776381] dwc2 20980000.usb: new device is full-speed
+[171134.814604] dwc2 20980000.usb: new address 1
+[171141.451306] dwc2 20980000.usb: new device is full-speed
+[171141.615170] dwc2 20980000.usb: new device is full-speed
+[171141.653405] dwc2 20980000.usb: new address 1
+[171144.695230] systemd-fstab-generator[7154]: Checking was requested for "/piusb.bin", but it is not a device.
+[171152.437209] systemd-fstab-generator[7184]: Checking was requested for "/piusb.bin", but it is not a device.
+[171160.014422] systemd-fstab-generator[7219]: Checking was requested for "/piusb.bin", but it is not a device.
+[171167.303899] systemd-fstab-generator[7240]: Checking was requested for "/piusb.bin", but it is not a device.
+[171171.961745] Mass Storage Function, version: 2009/09/11
+[171171.961781] LUN: removable file: (no medium)
+[171171.961961] LUN: removable file: /piusb.bin
+[171171.961983] Number of LUNs=1
+[171171.971615] g_mass_storage gadget.0: Mass Storage Gadget, version: 2009/09/11
+[171171.971653] g_mass_storage gadget.0: userspace failed to provide iSerialNumber
+[171171.971668] g_mass_storage gadget.0: g_mass_storage ready
+**[171171.971685] dwc2 20980000.usb: bound driver g_mass_storage
+[171172.236378] dwc2 20980000.usb: new device is full-speed
+[171172.400195] dwc2 20980000.usb: new device is full-speed
+[171172.438425] dwc2 20980000.usb: new address 1**
+```

--- a/README.md
+++ b/README.md
@@ -340,3 +340,22 @@ To test things out, open your favourite slicer, generate some g-code and save it
 If it works, good job! 👏🥂🥳🎉🎊
 
 If not, I'm sorry! 😢😭😿
+
+## Troubleshooting
+### g_multi driver vs g_mass_storage driver
+Some printers may not work with the g_multi driver, which produces a "single USB configuration with RNDIS[1] (that is Ethernet), USB CDC[2] ACM (that is serial) and USB Mass Storage functions."
+If this is the case, and your files do not show up on your printer using the install script, you can use this troubleshooting.
+Open an SSH shell to your pi, and run `sudo dmesg -w` and watch if this log gets printed repeatedly, it is just looping on this, then it means the printer will not use this USB device.
+```
+[167504.484474] dwc2 20980000.usb: new device is full-speed
+[167504.648298] dwc2 20980000.usb: new device is full-speed
+[167504.686546] dwc2 20980000.usb: new address 1
+```
+If this is the case, open the file `/usr/local/share/usbshare.py` and change the CMD lines to this, and restart the pi:
+```
+CMD_MOUNT = "sudo /sbin/modprobe g_mass_storage file=/piusb.bin stall=0 ro=1 removable=y"
+CMD_UNMOUNT = "sudo /sbin/modprobe g_mass_storage -r"
+```
+
+//TODO, provide a command in the install script to automatically change that, 
+

--- a/README.md
+++ b/README.md
@@ -376,8 +376,8 @@ If you are watching `sudo dmesg -w` in another ssh session, you will see this ch
 [171171.971615] g_mass_storage gadget.0: Mass Storage Gadget, version: 2009/09/11
 [171171.971653] g_mass_storage gadget.0: userspace failed to provide iSerialNumber
 [171171.971668] g_mass_storage gadget.0: g_mass_storage ready
-**[171171.971685] dwc2 20980000.usb: bound driver g_mass_storage
+[171171.971685] dwc2 20980000.usb: bound driver g_mass_storage
 [171172.236378] dwc2 20980000.usb: new device is full-speed
 [171172.400195] dwc2 20980000.usb: new device is full-speed
-[171172.438425] dwc2 20980000.usb: new address 1**
+[171172.438425] dwc2 20980000.usb: new address 1
 ```

--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ if [[ "g_mass_storage" = "$1" ]]; then
     DRIVER_TO_USE="g_mass_storage"
 fi
 
-echo "Service is currently $ACTIVE_STATUS"
+
 # Known compatible hardware models
 COMPATIBLE_MODELS=("Raspberry Pi Zero W Rev 1.1" "Raspberry Pi Zero 2 W Rev 1.0")
 
@@ -224,6 +224,7 @@ append_text_to_file "$samba_block" "/etc/samba/smb.conf" "[usb]"
 sudo systemctl restart smbd
 ACTIVE_STATUS=$(systemctl is-active usbshare.service)
 if [[ "$ACTIVE_STATUS" = "active" ]]; then
+    echo "Service is currently active, shutting down"
     sudo systemctl disable usbshare.service
     sudo modprobe g_multi -r
     sudo modprobe g_mass_storage -r

--- a/install.sh
+++ b/install.sh
@@ -229,6 +229,7 @@ if [[ "$ACTIVE_STATUS" = "active" ]]; then
     sudo systemctl disable usbshare.service
     sudo modprobe g_multi -r
     sudo modprobe g_mass_storage -r
+    sudo systemctl daemon-reload
 fi
 # Copy usbshare.py script
 if [ -f "usbshare.py" ]; then

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ if [ "$USE_EXISTING_FOLDER" = "no" ]; then
     sudo mkdir "$MOUNT_FOLDER"
     sudo chmod 777 "$MOUNT_FOLDER"
 fi
-append_text_to_file "/piusb.bin $MOUNT_FOLDER vfat users,umask=000 0 2" "/etc/fstab" "piusb.bin"
+append_text_to_file "/piusb.bin $MOUNT_FOLDER vfat users,umask=000 0 2" "/etc/fstab" "/piusb.bin $MOUNT_FOLDER vfat users,umask=000 0 2"
 sudo mount -a
 
 # Configure Samba

--- a/install.sh
+++ b/install.sh
@@ -225,6 +225,7 @@ sudo systemctl restart smbd
 ACTIVE_STATUS=$(systemctl is-active usbshare.service)
 if [[ "$ACTIVE_STATUS" = "active" ]]; then
     echo "Service is currently active, shutting down"
+    sudo systemctl stop usbshare.service
     sudo systemctl disable usbshare.service
     sudo modprobe g_multi -r
     sudo modprobe g_mass_storage -r

--- a/install.sh
+++ b/install.sh
@@ -225,6 +225,8 @@ sudo systemctl restart smbd
 ACTIVE_STATUS=$(systemctl is-active usbshare.service)
 if [[ "$ACTIVE_STATUS" = "active" ]]; then
     sudo systemctl disable usbshare.service
+    sudo modprobe g_multi -r
+    sudo modprobe g_mass_storage -r
 fi
 # Copy usbshare.py script
 if [ -f "usbshare.py" ]; then

--- a/install.sh
+++ b/install.sh
@@ -230,7 +230,7 @@ fi
 if [ -f "usbshare.py" ]; then
     sudo cp usbshare.py /usr/local/share/usbshare.py
     sudo chmod +x /usr/local/share/usbshare.py
-    if [[ "$DRIVER_TO_USE" = "g_mass_storage" ]; then
+    if [[ "$DRIVER_TO_USE" = "g_mass_storage" ]]; then
         sudo sed -i 's/g_multi/g_mass_storage/g' /usr/local/share/usbshare.py
     fi
 else

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ REQUIRED_SPACE_MB=$((USB_FILE_SIZE_MB + 1024)) # Required space including buffer
 MOUNT_FOLDER="/mnt/usb_share"
 USE_EXISTING_FOLDER="no"
 DRIVER_TO_USE="g_multi"
-if [[ "g_mass_storage" == "$1" ]]; then
+if [[ "g_mass_storage" = "$1" ]]; then
     DRIVER_TO_USE="g_mass_storage"
 fi
 
@@ -204,7 +204,7 @@ if [ "$USE_EXISTING_FOLDER" = "no" ]; then
     sudo mkdir "$MOUNT_FOLDER"
     sudo chmod 777 "$MOUNT_FOLDER"
 fi
-append_text_to_file "/piusb.bin $MOUNT_FOLDER vfat users,umask=000 0 2" "/etc/fstabs" "piusb.bin"
+append_text_to_file "/piusb.bin $MOUNT_FOLDER vfat users,umask=000 0 2" "/etc/fstab" "piusb.bin"
 sudo mount -a
 
 # Configure Samba
@@ -223,14 +223,14 @@ append_text_to_file "$samba_block" "/etc/samba/smb.conf" "[usb]"
 # Restart Samba services
 sudo systemctl restart smbd
 ACTIVE_STATUS=$(systemctl is-active usbshare.service)
-if [[ "$ACTIVE_STATUS" == "active" ]]; then
+if [[ "$ACTIVE_STATUS" = "active" ]]; then
     sudo systemctl disable usbshare.service
 fi
 # Copy usbshare.py script
 if [ -f "usbshare.py" ]; then
     sudo cp usbshare.py /usr/local/share/usbshare.py
     sudo chmod +x /usr/local/share/usbshare.py
-    if [[ "$DRIVER_TO_USE" == "g_mass_storage" ]; then
+    if [[ "$DRIVER_TO_USE" = "g_mass_storage" ]; then
         sudo sed -i 's/g_multi/g_mass_storage/g' /usr/local/share/usbshare.py
     fi
 else

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ DRIVER_TO_USE="g_multi"
 if [[ "g_mass_storage" == "$1" ]]; then
     DRIVER_TO_USE="g_mass_storage"
 fi
-ACTIVE_STATUS=$(systemctl is-active usbshare.service)
+
 echo "Service is currently $ACTIVE_STATUS"
 # Known compatible hardware models
 COMPATIBLE_MODELS=("Raspberry Pi Zero W Rev 1.1" "Raspberry Pi Zero 2 W Rev 1.0")
@@ -222,7 +222,10 @@ append_text_to_file "$samba_block" "/etc/samba/smb.conf" "[usb]"
 
 # Restart Samba services
 sudo systemctl restart smbd
-
+ACTIVE_STATUS=$(systemctl is-active usbshare.service)
+if [[ "$ACTIVE_STATUS" == "active" ]]; then
+    sudo systemctl disable usbshare.service
+fi
 # Copy usbshare.py script
 if [ -f "usbshare.py" ]; then
     sudo cp usbshare.py /usr/local/share/usbshare.py


### PR DESCRIPTION
This change gives the user the ability to choose the g_mass_storage driver.
It also fixes an issue where the fstab was being written to multiple times if the install script was run repeatedly.
It also shuts down the existing service if it is already running.

I have not tested this as a fresh install, only as a replacement of the existing.

I do not know how to squash commits on github, but if that is not an option you have, I'm happy to reset my branch and do a new one with only 1 commit.